### PR TITLE
Resolve issues with static asserts in SIZEOF evaluation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,10 @@ debug
 dep
 obj
 dev-env
+toolchain/
 src/glyphs.c
 src/glyphs.h
 
 # Rule out IDE-s
 .idea
 .vscode
-

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ APP_LOAD_PARAMS= --curve secp256k1 --path "44'/60'" --appFlags 0x240 $(COMMON_LO
 
 APPVERSION_M=1
 APPVERSION_N=0
-APPVERSION_P=4
+APPVERSION_P=5
 APPVERSION=$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)
 APPNAME = "Fantom FTM"
 
@@ -46,11 +46,15 @@ all: default
 ############
 # Platform #
 ############
-
 DEFINES   += OS_IO_SEPROXYHAL
 DEFINES   += HAVE_BAGL HAVE_SPRINTF
-DEFINES   += HAVE_IO_USB HAVE_L4_USBLIB IO_USB_MAX_ENDPOINTS=6 IO_HID_EP_LENGTH=64 HAVE_USB_APDU
 DEFINES   += LEDGER_MAJOR_VERSION=$(APPVERSION_M) LEDGER_MINOR_VERSION=$(APPVERSION_N) LEDGER_PATCH_VERSION=$(APPVERSION_P)
+
+DEFINES   += UNUSED\(x\)=\(void\)x
+DEFINES   += APPVERSION=\"$(APPVERSION)\"
+
+# USB HID
+DEFINES += HAVE_IO_USB HAVE_L4_USBLIB IO_USB_MAX_ENDPOINTS=4 IO_HID_EP_LENGTH=64 HAVE_USB_APDU
 
 # U2F
 DEFINES   += HAVE_U2F HAVE_IO_U2F
@@ -58,34 +62,32 @@ DEFINES   += U2F_PROXY_MAGIC=\"FTM\"
 DEFINES   += USB_SEGMENT_SIZE=64
 DEFINES   += BLE_SEGMENT_SIZE=32 #max MTU, min 20
 
-WEBUSB_URL     = pwawallet.fantom.network
-DEFINES       += HAVE_WEBUSB WEBUSB_URL_SIZE_B=$(shell echo -n $(WEBUSB_URL) | wc -c) WEBUSB_URL=$(shell echo -n $(WEBUSB_URL) | sed -e "s/./\\\'\0\\\',/g")
-
-DEFINES   += UNUSED\(x\)=\(void\)x
-DEFINES   += APPVERSION=\"$(APPVERSION)\"
+# WebUSB
+DEFINES   += HAVE_WEBUSB WEBUSB_URL_SIZE_B=0 WEBUSB_URL=""
 
 # Protect stack overflows
 DEFINES += HAVE_BOLOS_APP_STACK_CANARY
 
+# Bluetooth
 ifeq ($(TARGET_NAME),TARGET_NANOX)
-DEFINES   	  += IO_SEPROXYHAL_BUFFER_SIZE_B=300
-DEFINES       += HAVE_BLE BLE_COMMAND_TIMEOUT_MS=2000
-DEFINES       += HAVE_BLE_APDU # basic ledger apdu transport over BLE
+    DEFINES   	  += IO_SEPROXYHAL_BUFFER_SIZE_B=300
+    DEFINES       += HAVE_BLE BLE_COMMAND_TIMEOUT_MS=2000
+    DEFINES       += HAVE_BLE_APDU # basic ledger apdu transport over BLE
 
-DEFINES       += HAVE_GLO096
-DEFINES       += HAVE_BAGL BAGL_WIDTH=128 BAGL_HEIGHT=64
-DEFINES       += HAVE_BAGL_ELLIPSIS # long label truncation feature
-DEFINES       += HAVE_BAGL_FONT_OPEN_SANS_REGULAR_11PX
-DEFINES       += HAVE_BAGL_FONT_OPEN_SANS_EXTRABOLD_11PX
-DEFINES       += HAVE_BAGL_FONT_OPEN_SANS_LIGHT_16PX
+    DEFINES       += HAVE_GLO096
+    DEFINES       += HAVE_BAGL BAGL_WIDTH=128 BAGL_HEIGHT=64
+    DEFINES       += HAVE_BAGL_ELLIPSIS # long label truncation feature
+    DEFINES       += HAVE_BAGL_FONT_OPEN_SANS_REGULAR_11PX
+    DEFINES       += HAVE_BAGL_FONT_OPEN_SANS_EXTRABOLD_11PX
+    DEFINES       += HAVE_BAGL_FONT_OPEN_SANS_LIGHT_16PX
 else
-DEFINES   	  += IO_SEPROXYHAL_BUFFER_SIZE_B=128
+    DEFINES   	  += IO_SEPROXYHAL_BUFFER_SIZE_B=128
 endif
 
 # Both nano S and X benefit from the flow.
 DEFINES       += HAVE_UX_FLOW
 
-
+# Reset the device on crash
 DEFINES += RESET_ON_CRASH
 
 # Enabling debug PRINTF
@@ -103,20 +105,6 @@ endif
 ##############
 #  Compiler  #
 ##############
-ifneq ($(BOLOS_ENV),)
-$(info BOLOS_ENV=$(BOLOS_ENV))
-CLANGPATH := $(BOLOS_ENV)/clang-arm-fropi/bin/
-GCCPATH := $(BOLOS_ENV)/gcc-arm-none-eabi-5_3-2016q1/bin/
-else
-$(info BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH)
-endif
-ifeq ($(CLANGPATH),)
-$(info CLANGPATH is not set: clang will be used from PATH)
-endif
-ifeq ($(GCCPATH),)
-$(info GCCPATH is not set: arm-none-eabi-* will be used from PATH)
-endif
-
 CC       := $(CLANGPATH)clang
 
 #CFLAGS   += -O0
@@ -160,7 +148,6 @@ include $(BOLOS_SDK)/Makefile.rules
 
 #add dependency on custom makefile filename
 dep/%.d: %.c Makefile
-
 
 
 listvariants:

--- a/prepare-devenv.sh
+++ b/prepare-devenv.sh
@@ -24,46 +24,74 @@ if [[ $(cat /etc/udev/rules.d/20-hw1.rules) == *'ATTRS{idVendor}=="2c97", ATTRS{
     return
 fi
 
-
 if [ ! -d dev-env ]; then
+    # toolchain elements
+    GCC_ARCHIVE="gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2"
+    CLANG4_ARCHIVE="clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-16.10.tar.xz"
+    CLANG7_ARCHIVE="clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz"
+    LEDGER_BLUE_SDK_ARCHIVE="blue-r21.1.tar.gz"
+    LEDGER_NANOS_SDK_ARCHIVE="nanos-1612.tar.gz"
+
+    # setup directories
     mkdir dev-env
     mkdir dev-env/SDK
     mkdir dev-env/CC
     mkdir dev-env/CC/others
     mkdir dev-env/CC/nanox
 
-    wget https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2
-    tar xf gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2
-    rm gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2
+    # where to keep the toolchain
+    if [ ! -d toolchain ]; then
+       mkdir toolchain
+    fi
+
+    # prepare GCC
+    echo "Preparing GCC ..."
+    if [ ! -f ${GCC_ARCHIVE} ]; then
+        wget "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/${GCC_ARCHIVE}" -O "toolchain/${GCC_ARCHIVE}"
+    fi
+    tar xf "toolchain/${GCC_ARCHIVE}" -C ./
     cp -r gcc-arm-none-eabi-5_3-2016q1 dev-env/CC/nanox/gcc-arm-none-eabi-5_3-2016q1
     mv gcc-arm-none-eabi-5_3-2016q1 dev-env/CC/others/gcc-arm-none-eabi-5_3-2016q1
 
-    wget http://releases.llvm.org/4.0.0/clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-16.10.tar.xz -O clang+llvm.tar.xz
-    tar xf clang+llvm.tar.xz
-    rm clang+llvm.tar.xz
-    mv clang+llvm* dev-env/CC/others/clang-arm-fropi
+    # clang 4.0
+    echo "Preparing LLVM v4 ..."
+    if [ ! -f ${CLANG4_ARCHIVE} ]; then
+        wget "http://releases.llvm.org/4.0.0/${CLANG4_ARCHIVE}" -O "toolchain/${CLANG4_ARCHIVE}"
+    fi
+    tar xf "toolchain/${CLANG4_ARCHIVE}" -C ./
+    mv "clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-16.10" dev-env/CC/others/clang-arm-fropi
 
-    wget http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz -O clang+llvm.tar.xz
-    tar xf clang+llvm.tar.xz
-    rm clang+llvm.tar.xz
-    mv clang+llvm* dev-env/CC/nanox/clang-arm-fropi
+    # clang 7.0
+    echo "Preparing LLVM v7 ..."
+    if [ ! -f ${CLANG7_ARCHIVE} ]; then
+        wget "http://releases.llvm.org/7.0.0/${CLANG7_ARCHIVE}" -O "toolchain/${CLANG7_ARCHIVE}"
+    fi
+    tar xf "toolchain/${CLANG7_ARCHIVE}" -C ./
+    mv "clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04" dev-env/CC/nanox/clang-arm-fropi
 
-    wget https://github.com/LedgerHQ/blue-secure-sdk/archive/blue-r21.1.tar.gz -O blue-secure-sdk.tar.gz
-    tar xf blue-secure-sdk.tar.gz
-    rm blue-secure-sdk.tar.gz
+    # Blue SDK
+    echo "Preparing Blue SDK ..."
+    if [ ! -f ${LEDGER_BLUE_SDK_ARCHIVE} ]; then
+        wget "https://github.com/LedgerHQ/blue-secure-sdk/archive/${LEDGER_BLUE_SDK_ARCHIVE}" -O "toolchain/${LEDGER_BLUE_SDK_ARCHIVE}"
+    fi
+    tar xf "toolchain/${LEDGER_BLUE_SDK_ARCHIVE}" -C ./
     mv blue-secure-sdk* dev-env/SDK/blue-secure-sdk
 
-    wget https://github.com/LedgerHQ/nanos-secure-sdk/archive/nanos-160.tar.gz -O nanos-secure-sdk.tar.gz
-    tar xf nanos-secure-sdk.tar.gz
-    rm nanos-secure-sdk.tar.gz
+    # NanoS SDK
+    echo "Preparing Nano-S SDK ..."
+    if [ ! -f ${LEDGER_NANOS_SDK_ARCHIVE} ]; then
+        wget "https://github.com/LedgerHQ/nanos-secure-sdk/archive/${LEDGER_NANOS_SDK_ARCHIVE}" -O "toolchain/${LEDGER_NANOS_SDK_ARCHIVE}"
+    fi
+    tar xf "toolchain/${LEDGER_NANOS_SDK_ARCHIVE}" -C ./
     mv nanos-secure-sdk* dev-env/SDK/nanos-secure-sdk
 
+    # Python environment
+    echo "Preparing Python environment ..."
     python3 -m venv dev-env/ledger_py3
     source dev-env/ledger_py3/bin/activate
     pip install wheel
     pip install ledgerblue
 fi
-
 
 source dev-env/ledger_py3/bin/activate
 

--- a/src/assert.h
+++ b/src/assert.h
@@ -7,9 +7,6 @@
 // declare the actual function we use for assertion processing
 extern void assert(int cond, const char *msgStr);
 
-// substitutes function above, but it's more eye catching
-#define ASSERT_WITH_MSG(cond, msg) assert(cond, msg)
-
 // max length of an assert we allow
 #define _MAX_ASSERT_LENGTH_ 25
 

--- a/src/bip44.c
+++ b/src/bip44.c
@@ -163,7 +163,7 @@ void bip44_pathToStr(const bip44_path_t *path, char *out, size_t outSize) {
         /* make sure we have enough space left */ \
         ASSERT(ptr <= end); \
         /* make sure the buffer is of the right type */ \
-        STATIC_ASSERT(sizeof(end - ptr) == sizeof(size_t), "bad size_t size"); \
+        ASSERT(sizeof(end - ptr) == sizeof(size_t)); \
         /* how much space do we have left */ \
         size_t availableSize = (size_t) (end - ptr); \
         /* push the formatted string */ \

--- a/src/derive_key.c
+++ b/src/derive_key.c
@@ -33,7 +33,7 @@ void derivePrivateKey(
     uint8_t privateKeyRawBuffer[RAW_PRIVATE_KEY_BUFFER];
 
     // make sure we can safely erase chain code container since it's the right size
-    STATIC_ASSERT(SIZEOF(chainCode->code) == CHAIN_CODE_SIZE, "bad chain code length");
+    ASSERT(SIZEOF(chainCode->code) == CHAIN_CODE_SIZE);
     os_memset(chainCode->code, 0, SIZEOF(chainCode->code));
 
     // do the extraction
@@ -45,7 +45,7 @@ void derivePrivateKey(
             STATIC_ASSERT(CX_APILEVEL >= API_LEVEL_MIN, "unsupported api level");
 
             // make sure the private key is of expected size
-            STATIC_ASSERT(SIZEOF(privateKey->d) == RAW_PRIVATE_KEY_SIZE, "bad private key length");
+            ASSERT(SIZEOF(privateKey->d) == RAW_PRIVATE_KEY_SIZE);
 
             // call for private key derivation
             io_seproxyhal_io_heartbeat();
@@ -85,7 +85,7 @@ void extractRawPublicKey(
         uint8_t *outBuffer, size_t outSize
 ) {
     // make sure the public key size is what we expect here
-    STATIC_ASSERT(SIZEOF(publicKey->W) == 65, "bad public key length");
+    ASSERT(SIZEOF(publicKey->W) == 65);
 
     // make sure the output buffer size corresponds with expected key size
     ASSERT(outSize == PUBLIC_KEY_SIZE);
@@ -113,7 +113,7 @@ void deriveExtendedPublicKey(
 
     // make sure the output structure is of the right dimension
     // the 1st byte is for public key length, others are for the public key and chain code
-    STATIC_ASSERT(SIZEOF(*out) == 1 + PUBLIC_KEY_SIZE + CHAIN_CODE_SIZE, "bad ext pub key size");
+    ASSERT(SIZEOF(*out) == 1 + PUBLIC_KEY_SIZE + CHAIN_CODE_SIZE);
 
     BEGIN_TRY
     {
@@ -133,17 +133,17 @@ void deriveExtendedPublicKey(
             deriveRawPublicKey(&privateKey, &publicKey);
 
             // make sure the public key size corresponds with our expectation
-            STATIC_ASSERT(SIZEOF(out->publicKey) == PUBLIC_KEY_SIZE, "bad pub key size");
+            ASSERT(SIZEOF(out->publicKey) == PUBLIC_KEY_SIZE);
 
             // extract the public key data to the output buffer
             extractRawPublicKey(&publicKey, out->publicKey, SIZEOF(out->publicKey));
             out->length = PUBLIC_KEY_SIZE;
 
             // make sure the chain code container size is what we expect
-            STATIC_ASSERT(CHAIN_CODE_SIZE == SIZEOF(out->chainCode), "bad chain code size");
+            ASSERT(CHAIN_CODE_SIZE == SIZEOF(out->chainCode));
 
             // make sure the chain code source data is of the expected size
-            STATIC_ASSERT(CHAIN_CODE_SIZE == SIZEOF(chainCode.code), "bad chain code size");
+            ASSERT(CHAIN_CODE_SIZE == SIZEOF(chainCode.code));
 
             // chain code is placed after the public key
             os_memmove(out->chainCode, chainCode.code, CHAIN_CODE_SIZE);

--- a/src/get_address.c
+++ b/src/get_address.c
@@ -1,7 +1,6 @@
 #include "common.h"
 #include "get_address.h"
 #include "derive_key.h"
-#include "endian.h"
 #include "state.h"
 #include "policy.h"
 #include "ui_helpers.h"

--- a/src/main.c
+++ b/src/main.c
@@ -41,7 +41,7 @@ void ui_idle(void) {
     ux_flow_init(0, ux_idle_flow, NULL);
 #else
     // unknown device?
-    STATIC_ASSERT(false);
+    STATIC_ASSERT(false, "unknown target device");
 #endif
 }
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -57,10 +57,10 @@ void txGetSignature(
     uint8_t sig[100];
 
     // make sure the signature is of expected length (v + r + s)
-    STATIC_ASSERT(SIZEOF(*signature) == 1 + TX_SIGNATURE_HASH_LENGTH + TX_SIGNATURE_HASH_LENGTH, "bad signature size");
+    ASSERT(SIZEOF(*signature) == 1 + TX_SIGNATURE_HASH_LENGTH + TX_SIGNATURE_HASH_LENGTH);
 
     // make sure the space for the derived sender address is enough
-    STATIC_ASSERT(SIZEOF(*sender) == 1 + TX_MAX_ADDRESS_LENGTH, "bad sender address size");
+    ASSERT(SIZEOF(*sender) == 1 + TX_MAX_ADDRESS_LENGTH);
 
     // validate hash size
     ASSERT(hashLength == TX_HASH_LENGTH);

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,10 +23,6 @@
 // Safe version of SIZEOF, does not compile if you accidentally supply a pointer.
 #define SIZEOF(var) (sizeof(var) + SIZEOF_NOT_A_PTR(var))
 
-// Validate the expression type.
-#define ASSERT_TYPE(expr, expected_type) \
-    STATIC_ASSERT( __builtin_types_compatible_p(__typeof__((expr)), expected_type), "Wrong type")
-
 // Given that memset is root of many problems, a bit of paranoia is good.
 #define MEMCLEAR(ptr, expected_type) \
     do { \


### PR DESCRIPTION
The build environment toolchain may not recognise sizeof() calls as integral constants and so refuses to evaluate them inside static asserts. Regular asserts are used in testing environment instead to make sure the app contains correct and expected default containers.